### PR TITLE
Don't force-activate the center editor (fixes #4, fixes #3).

### DIFF
--- a/lib/collapse-then-reveal.js
+++ b/lib/collapse-then-reveal.js
@@ -43,11 +43,14 @@ function main (e) {
     this.activeID = (activePane.activeItem || {}).id
 
     // Collapse inactive items
-    const panelElement = atom.packages.getActivePackage(
-      'tree-view'
-    ).mainModule.treeView.roots[0]
-    panelElement.collapse(true)
-    panelElement.expand()
+    atom.packages.getActivePackage('tree-view')
+      .mainModule
+      .treeView
+      .roots
+      .forEach(panelElement => {
+        panelElement.collapse(true)
+        panelElement.expand()
+      });
 
     // Reveal active item
     const workspaceView = atom.views.getView(atom.workspace)

--- a/lib/collapse-then-reveal.js
+++ b/lib/collapse-then-reveal.js
@@ -33,15 +33,6 @@ function isTreeViewOpen () {
 }
 
 function main (e) {
-  // Activate center (TextEditor) if TreeView is active instead
-  if (
-    !e ||
-    !e.hasOwnProperty('buffer') ||
-    !atom.workspace.getActivePane().activeItem
-  ) {
-    atom.workspace.getCenter && atom.workspace.getCenter().activate()
-  }
-
   // Prevent executing twice within a single active pane change
   const activePane = atom.workspace.getActivePane()
   const isNewActivePane = (activePane.activeItem || {}).id !== this.activeID &&


### PR DESCRIPTION
Removes the logic that attempts to activate the center editor if the `TreeView` is active, since it tends to incorrectly catch the Git panel as well. This closes the issues related to integration with Atom's built-in Git package.